### PR TITLE
feat(useWebSocket): allow different heartbeat response message

### DIFF
--- a/packages/core/useWebSocket/index.ts
+++ b/packages/core/useWebSocket/index.ts
@@ -26,7 +26,12 @@ export interface UseWebSocketOptions {
      * @default 'ping'
      */
     message?: string | ArrayBuffer | Blob
-
+    
+    /**
+     * Response message for the heartbeat, if undefined the message will be used
+     */
+    responseMessage?: string | ArrayBuffer | Blob
+    
     /**
      * Interval, in milliseconds
      *
@@ -251,8 +256,9 @@ export function useWebSocket<Data = any>(
         resetHeartbeat()
         const {
           message = DEFAULT_PING_MESSAGE,
+          responseMessage
         } = resolveNestedOptions(options.heartbeat)
-        if (e.data === message)
+        if (e.data === (responseMessage === undefined ? message : responseMessage))
           return
       }
 


### PR DESCRIPTION
### Description

As mentioned in [#2861](https://github.com/vueuse/vueuse/issues/2861), it can be useful to provide a custom response message. 
For example, AWS does not charge for a ping/pong request, but with the current implementation the request must be ping/ping.
I made changes to be backwards compatible with the existing user implementation.

### Additional context

In my opinion, the default responseMessage should be "pong", but it will be a breaking change.
